### PR TITLE
Adds module and default imports

### DIFF
--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -338,9 +338,15 @@ pub struct ImportDefaultDeclaration {
 }
 
 #[derive(Debug, PartialEq)]
+pub struct ImportNamespaceSpecifier {
+    pub local: Id,
+}
+
+#[derive(Debug, PartialEq)]
 pub enum ImportSpecification {
     ImportSpecifier(ImportSpecifier),
-    ImportDefaultDeclaration(ImportDefaultDeclaration)
+    ImportDefaultDeclaration(ImportDefaultDeclaration),
+    ImportNamespaceSpecifier(ImportNamespaceSpecifier)
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -327,6 +327,17 @@ pub struct ExportDefaultDeclaration {
 }
 
 #[derive(Debug, PartialEq)]
+pub struct ImportDefaultDeclaration {
+    pub identifier: Id
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ImportDeclaration {
+    pub source: StringLiteral,
+    pub specifiers: Vec<ImportDefaultDeclaration>,
+}
+
+#[derive(Debug, PartialEq)]
 pub enum Statement {
     Expression(Span, Expression),
     VariableDeclaration(VariableDeclaration),
@@ -352,7 +363,8 @@ pub enum Statement {
     Directive(Span, Expression, String),
     ExportNamedDeclaration(Span, ExportNamedDeclaration),
     ExportDefaultDeclaration(Span, ExportDefaultDeclaration),
-    ExportAllDeclaration(Span, StringLiteral)
+    ExportAllDeclaration(Span, StringLiteral),
+    ImportDeclaration(Span, ImportDeclaration),
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -327,14 +327,26 @@ pub struct ExportDefaultDeclaration {
 }
 
 #[derive(Debug, PartialEq)]
+pub struct ImportSpecifier {
+    pub local: Id,
+    pub imported: Id
+}
+
+#[derive(Debug, PartialEq)]
 pub struct ImportDefaultDeclaration {
     pub identifier: Id
 }
 
 #[derive(Debug, PartialEq)]
+pub enum ImportSpecification {
+    ImportSpecifier(ImportSpecifier),
+    ImportDefaultDeclaration(ImportDefaultDeclaration)
+}
+
+#[derive(Debug, PartialEq)]
 pub struct ImportDeclaration {
     pub source: StringLiteral,
-    pub specifiers: Vec<ImportDefaultDeclaration>,
+    pub specifiers: Vec<ImportSpecification>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/syntax/char.rs
+++ b/src/syntax/char.rs
@@ -1,5 +1,3 @@
-use std::ascii::AsciiExt;
-
 macro_rules! match_one_char_class {
     ( ( $start:expr, $end:expr ) ) => {
         $start ... $end

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -2023,8 +2023,14 @@ impl<'a> Parser<'a> {
     }
 
     fn parser_import_specification(&mut self) -> Result<ImportSpecification> {
-        let local = self.parse_identifier_name()?;
-        let imported = local.clone();
+        let imported = self.parse_identifier_name()?;
+        let local = if self.match_contextual_keyword(interner::RESERVED_AS) {
+            self.scanner.next_token()?;
+            self.parse_identifier_name()?
+        } else {
+            imported.clone()
+        };
+
         Ok(ImportSpecification::ImportSpecifier(ImportSpecifier {
             local: local,
             imported: imported,

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -2042,6 +2042,20 @@ impl<'a> Parser<'a> {
         self.expect(Token::ImportKeyword)?;
 
         match self.scanner.lookahead {
+            Token::Star => {
+                self.scanner.next_token()?;
+                self.expect(Token::Ident(interner::RESERVED_AS))?;
+                let local = self.parse_identifier_name()?;
+                self.expect(Token::Ident(interner::RESERVED_FROM))?;
+                let source = self.parse_module_specifier()?;
+
+                let specifiers = vec!(ImportSpecification::ImportNamespaceSpecifier(ImportNamespaceSpecifier{local: local}));
+
+                Ok(Statement::ImportDeclaration(
+                        self.consume_semicolon(start)?,
+                        ImportDeclaration { source, specifiers:  specifiers }
+                        ))
+            },
             Token::OpenCurly => {
                 self.expect(Token::OpenCurly)?;
 

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -2060,10 +2060,9 @@ impl<'a> Parser<'a> {
                 self.scanner.next_token()?;
                 self.expect(Token::Ident(interner::RESERVED_AS))?;
                 let local = self.parse_identifier_name()?;
+                let specifiers = vec!(ImportSpecification::ImportNamespaceSpecifier(ImportNamespaceSpecifier{local: local}));
                 self.expect(Token::Ident(interner::RESERVED_FROM))?;
                 let source = self.parse_module_specifier()?;
-
-                let specifiers = vec!(ImportSpecification::ImportNamespaceSpecifier(ImportNamespaceSpecifier{local: local}));
 
                 Ok(Statement::ImportDeclaration(
                         self.consume_semicolon(start)?,
@@ -2072,7 +2071,6 @@ impl<'a> Parser<'a> {
             },
             Token::OpenCurly => {
                 let mut specifiers = self.parse_multiple_import_specifiers()?;
-
                 self.expect(Token::Ident(interner::RESERVED_FROM))?;
                 let source = self.parse_module_specifier()?;
                 Ok(Statement::ImportDeclaration(
@@ -2090,7 +2088,15 @@ impl<'a> Parser<'a> {
 
                 if self.scanner.lookahead == Token::Comma {
                     self.scanner.next_token()?;
-                    specifiers.append(&mut self.parse_multiple_import_specifiers()?);
+
+                    if self.scanner.lookahead == Token::Star {
+                        self.scanner.next_token()?;
+                        self.expect(Token::Ident(interner::RESERVED_AS))?;
+                        let local = self.parse_identifier_name()?;
+                        specifiers.push(ImportSpecification::ImportNamespaceSpecifier(ImportNamespaceSpecifier{local: local}));
+                    } else {
+                        specifiers.append(&mut self.parse_multiple_import_specifiers()?);
+                    }
                 }
 
                 self.expect(Token::Ident(interner::RESERVED_FROM))?;

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -2022,19 +2022,23 @@ impl<'a> Parser<'a> {
         })
     }
 
+    fn parse_import_specifier(&mut self) -> Result<ImportDefaultDeclaration> {
+        let id = self.parse_identifier_name()?;
+        Ok(ImportDefaultDeclaration {
+            identifier: id,
+        })
+    }
+
     fn parse_import_declaration(&mut self) -> Result<Statement> {
         let start = self.scanner.lookahead_start;
         self.expect(Token::ImportKeyword)?;
 
         match self.scanner.lookahead {
             Token::Ident(_) => {
-                let id = self.parse_identifier_name()?;
+                let declaration = self.parse_import_specifier()?;
                 self.expect(Token::Ident(interner::RESERVED_FROM))?;
                 let source = self.parse_module_specifier()?;
 
-                let declaration = ImportDefaultDeclaration {
-                    identifier: id,
-                };
 
                 Ok(Statement::ImportDeclaration(
                         self.consume_semicolon(start)?,

--- a/src/syntax/scanner.rs
+++ b/src/syntax/scanner.rs
@@ -616,6 +616,7 @@ impl<'a> Scanner<'a> {
             "with" => Token::WithKeyword,
             "yield" => Token::YieldKeyword,
             "export" => Token::ExportKeyword,
+            "import" => Token::ImportKeyword,
             _ => {
                 Token::Ident(interner::intern(value))
             }

--- a/src/syntax/token.rs
+++ b/src/syntax/token.rs
@@ -48,6 +48,7 @@ pub enum Token {
     If,
     In,
     Instanceof,
+    ImportKeyword,
     LShift,
     LShiftEq,
     LogicalAnd,

--- a/tests/esprima-ignore
+++ b/tests/esprima-ignore
@@ -19,7 +19,6 @@ ES2016/**
 es2017/**
 es2018/**
 
-ES6/import-declaration/import-default-and-named-specifiers
 ES6/import-declaration/import-default-and-namespace-specifiers
 ES6/import-declaration/invalid-import-boolean.module
 ES6/import-declaration/invalid-import-default-after-named-after-default.module

--- a/tests/esprima-ignore
+++ b/tests/esprima-ignore
@@ -19,6 +19,36 @@ ES2016/**
 es2017/**
 es2018/**
 
+ES6/import-declaration/import-default-and-named-specifiers
+ES6/import-declaration/import-default-and-namespace-specifiers
+ES6/import-declaration/import-default-as
+ES6/import-declaration/import-jquery
+ES6/import-declaration/import-named-as-specifier
+ES6/import-declaration/import-named-as-specifiers
+ES6/import-declaration/import-named-empty
+ES6/import-declaration/import-named-specifier
+ES6/import-declaration/import-named-specifiers-comma
+ES6/import-declaration/import-named-specifiers
+ES6/import-declaration/import-namespace-specifier
+ES6/import-declaration/import-null-as-nil
+ES6/import-declaration/invalid-import-boolean.module
+ES6/import-declaration/invalid-import-default-after-named-after-default.module
+ES6/import-declaration/invalid-import-default-after-named.module
+ES6/import-declaration/invalid-import-default-missing-module-specifier.module
+ES6/import-declaration/invalid-import-default-module-specifier.module
+ES6/import-declaration/invalid-import-default.module
+ES6/import-declaration/invalid-import-keyword.module
+ES6/import-declaration/invalid-import-missing-comma.module
+ES6/import-declaration/invalid-import-missing-module-specifier.module
+ES6/import-declaration/invalid-import-module-specifier.module
+ES6/import-declaration/invalid-import-named-after-named.module
+ES6/import-declaration/invalid-import-named-after-namespace.module
+ES6/import-declaration/invalid-import-named-as-missing-from.module
+ES6/import-declaration/invalid-import-namespace-after-named.module
+ES6/import-declaration/invalid-import-namespace-missing-as.module
+ES6/import-declaration/invalid-import-null.module
+ES6/import-declaration/invalid-import-specifiers.module
+
 # Not sure about these
 ES6/arrow-function/array-binding-pattern/invalid-dup-param
 ES6/arrow-function/invalid-duplicated-names-rest-parameter
@@ -38,7 +68,6 @@ ES6/export-declaration/invalid-export-batch-missing-from-clause.module
 ES6/export-declaration/invalid-export-batch-token.module
 
 ES6/identifier/**
-ES6/import-declaration/**
 ES6/meta-property/**
 ES6/program/**
 ES6/template-literals/**

--- a/tests/esprima-ignore
+++ b/tests/esprima-ignore
@@ -21,7 +21,6 @@ es2018/**
 
 ES6/import-declaration/import-default-and-named-specifiers
 ES6/import-declaration/import-default-and-namespace-specifiers
-ES6/import-declaration/import-namespace-specifier
 ES6/import-declaration/invalid-import-boolean.module
 ES6/import-declaration/invalid-import-default-after-named-after-default.module
 ES6/import-declaration/invalid-import-default-after-named.module

--- a/tests/esprima-ignore
+++ b/tests/esprima-ignore
@@ -26,7 +26,6 @@ ES6/import-declaration/import-jquery
 ES6/import-declaration/import-named-as-specifier
 ES6/import-declaration/import-named-as-specifiers
 ES6/import-declaration/import-named-empty
-ES6/import-declaration/import-named-specifier
 ES6/import-declaration/import-named-specifiers-comma
 ES6/import-declaration/import-named-specifiers
 ES6/import-declaration/import-namespace-specifier

--- a/tests/esprima-ignore
+++ b/tests/esprima-ignore
@@ -21,14 +21,7 @@ es2018/**
 
 ES6/import-declaration/import-default-and-named-specifiers
 ES6/import-declaration/import-default-and-namespace-specifiers
-ES6/import-declaration/import-jquery
-ES6/import-declaration/import-named-as-specifier
-ES6/import-declaration/import-named-as-specifiers
-ES6/import-declaration/import-named-empty
-ES6/import-declaration/import-named-specifiers-comma
-ES6/import-declaration/import-named-specifiers
 ES6/import-declaration/import-namespace-specifier
-ES6/import-declaration/import-null-as-nil
 ES6/import-declaration/invalid-import-boolean.module
 ES6/import-declaration/invalid-import-default-after-named-after-default.module
 ES6/import-declaration/invalid-import-default-after-named.module

--- a/tests/esprima-ignore
+++ b/tests/esprima-ignore
@@ -19,7 +19,6 @@ ES2016/**
 es2017/**
 es2018/**
 
-ES6/import-declaration/import-default-and-namespace-specifiers
 ES6/import-declaration/invalid-import-boolean.module
 ES6/import-declaration/invalid-import-default-after-named-after-default.module
 ES6/import-declaration/invalid-import-default-after-named.module

--- a/tests/esprima-ignore
+++ b/tests/esprima-ignore
@@ -21,7 +21,6 @@ es2018/**
 
 ES6/import-declaration/import-default-and-named-specifiers
 ES6/import-declaration/import-default-and-namespace-specifiers
-ES6/import-declaration/import-default-as
 ES6/import-declaration/import-jquery
 ES6/import-declaration/import-named-as-specifier
 ES6/import-declaration/import-named-as-specifiers

--- a/tests/json/mod.rs
+++ b/tests/json/mod.rs
@@ -743,13 +743,23 @@ fn export_named_declaration(node: &Value) -> Result<Statement> {
     }))
 }
 
-fn import_default_specifier(node: &Value) -> Result<ImportDefaultDeclaration> {
+fn named_import_specifier(node: &Value) -> Result<ImportSpecification> {
     let local = identifier(expect_value(node, "local"))?;
-    Ok(ImportDefaultDeclaration{ identifier: local})
+    let imported = identifier(expect_value(node, "imported"))?;
+
+    Ok(ImportSpecification::ImportSpecifier(ImportSpecifier{local: local, imported: imported}))
 }
 
-fn import_specifier(node: &Value) -> Result<ImportDefaultDeclaration> {
+fn import_default_specifier(node: &Value) -> Result<ImportSpecification> {
+    let local = identifier(expect_value(node, "local"))?;
+    Ok(ImportSpecification::ImportDefaultDeclaration(ImportDefaultDeclaration{ identifier: local}))
+}
+
+fn import_specifier(node: &Value) -> Result<ImportSpecification> {
     match expect_string(node, "type") {
+        "ImportSpecifier" => {
+            named_import_specifier(node)
+        }
         "ImportDefaultSpecifier" => {
             import_default_specifier(node)
         },

--- a/tests/json/mod.rs
+++ b/tests/json/mod.rs
@@ -743,6 +743,12 @@ fn export_named_declaration(node: &Value) -> Result<Statement> {
     }))
 }
 
+fn import_namespace_specifier(node: &Value) -> Result<ImportSpecification> {
+    let local = identifier(expect_value(node, "local"))?;
+
+    Ok(ImportSpecification::ImportNamespaceSpecifier(ImportNamespaceSpecifier{local: local}))
+}
+
 fn named_import_specifier(node: &Value) -> Result<ImportSpecification> {
     let local = identifier(expect_value(node, "local"))?;
     let imported = identifier(expect_value(node, "imported"))?;
@@ -762,6 +768,9 @@ fn import_specifier(node: &Value) -> Result<ImportSpecification> {
         }
         "ImportDefaultSpecifier" => {
             import_default_specifier(node)
+        },
+        "ImportNamespaceSpecifier" => {
+            import_namespace_specifier(node)
         },
         _ => Err(())
     }

--- a/tests/json/mod.rs
+++ b/tests/json/mod.rs
@@ -743,6 +743,36 @@ fn export_named_declaration(node: &Value) -> Result<Statement> {
     }))
 }
 
+fn import_default_specifier(node: &Value) -> Result<ImportDefaultDeclaration> {
+    let local = identifier(expect_value(node, "local"))?;
+    Ok(ImportDefaultDeclaration{ identifier: local})
+}
+
+fn import_specifier(node: &Value) -> Result<ImportDefaultDeclaration> {
+    match expect_string(node, "type") {
+        "ImportDefaultSpecifier" => {
+            import_default_specifier(node)
+        },
+        _ => Err(())
+    }
+}
+
+fn import_declaration(node: &Value) -> Result<Statement> {
+    let source = string_literal(expect_value(node, "source"))?;
+
+    let mut specifiers = Vec::new();
+    for s in expect_array(node, "specifiers")  {
+        specifiers.push(import_specifier(s)?)
+    }
+
+    let declaration = ImportDeclaration {
+        source: source,
+        specifiers: specifiers,
+    };
+
+    Ok(Statement::ImportDeclaration(span(node)?, declaration))
+}
+
 fn export_default_declaration(node: &Value) -> Result<Statement> {
     let val = expect_value(node, "declaration");
     let declaration = statement(val)
@@ -809,6 +839,7 @@ fn statement(node: &Value) -> Result<Statement> {
         "LabeledStatement" => labeled_statement(node),
         "ExportNamedDeclaration" => export_named_declaration(node),
         "ExportDefaultDeclaration" => export_default_declaration(node),
+        "ImportDeclaration" => import_declaration(node),
         "ExportAllDeclaration" => export_all_declaration(node),
         "BreakStatement" => {
             let id = maybe_key(node, "label", &identifier)?;


### PR DESCRIPTION
TODO:

* [x] ES6/import-declaration/import-default-as
* [x] ES6/import-declaration/import-named-specifier
* [x] ES6/import-declaration/import-named-specifiers
* [x] ES6/import-declaration/import-named-as-specifier
* [x] ES6/import-declaration/import-named-as-specifiers
* [x] ES6/import-declaration/import-named-specifiers-comma
* [x] ES6/import-declaration/import-named-empty
* [x] ES6/import-declaration/import-jquery
* [x] ES6/import-declaration/import-null-as-nil
* [x] ES6/import-declaration/import-namespace-specifier
* [x] ES6/import-declaration/import-default-and-named-specifiers
* [x] ES6/import-declaration/import-default-and-namespace-specifiers
* [ ] ES6/import-declaration/invalid-import-boolean.module
* [ ] ES6/import-declaration/invalid-import-default-after-named-after-default.module
* [ ] ES6/import-declaration/invalid-import-default-after-named.module
* [ ] ES6/import-declaration/invalid-import-default-missing-module-specifier.module
* [ ] ES6/import-declaration/invalid-import-default-module-specifier.module
* [ ] ES6/import-declaration/invalid-import-default.module
* [ ] ES6/import-declaration/invalid-import-keyword.module
* [ ] ES6/import-declaration/invalid-import-missing-comma.module
* [ ] ES6/import-declaration/invalid-import-missing-module-specifier.module
* [ ] ES6/import-declaration/invalid-import-module-specifier.module
* [ ] ES6/import-declaration/invalid-import-named-after-named.module
* [ ] ES6/import-declaration/invalid-import-named-after-namespace.module
* [ ] ES6/import-declaration/invalid-import-named-as-missing-from.module
* [ ] ES6/import-declaration/invalid-import-namespace-after-named.module
* [ ] ES6/import-declaration/invalid-import-namespace-missing-as.module
* [ ] ES6/import-declaration/invalid-import-null.module
* [ ] ES6/import-declaration/invalid-import-specifiers.module

